### PR TITLE
Relocate hide results link

### DIFF
--- a/ddghur.css
+++ b/ddghur.css
@@ -18,13 +18,15 @@
     margin-bottom: inherit;
 }
 .results .result .hideShowLink {
-    font-size: 11px;
     float:right;
     display:none;
-    position:absolute;
-    bottom:-4px;
-    right:10px;
-    opacity:.75
+    overflow: hidden;
+    max-width: 100px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.result__menu {
+    width: 15% !important;
 }
 .results .result.highlight .hideShowLink {
     display:inline-block;

--- a/ddghur.js
+++ b/ddghur.js
@@ -54,20 +54,17 @@ function hideResultLink(e){
 function addHideShowResultsForDomainLink(){
     let results = document.querySelectorAll(".results .result:not(.result--sep):not(.result--more):not(.hideResult)");
     for(let i=0; i<results.length; i++){
-        let resultUrl = results[i].querySelector(".result__body");
+        let resultUrl = results[i].querySelector(".result__body .result__extras");
         let resultHasHideLink = results[i].querySelectorAll(".hideShowLink");
         if(resultHasHideLink.length>0)
             continue;
         let resultDomain = results[i].dataset.domain;
         let link = document.createElement("a");
+        link.title = "Hide results from "+resultDomain
         link.dataset.domain = resultDomain;
         link.classList.add("hideShowLink");
-        let linkTxt = document.createTextNode("Hide results from ");
-        let linkDomain = document.createElement("span");
-        let linkDomainTxt = document.createTextNode("'"+resultDomain+"'");
-        linkDomain.appendChild(linkDomainTxt);
+        let linkTxt = document.createTextNode("Hide results");
         link.appendChild(linkTxt);
-        link.appendChild(linkDomain);
         resultUrl.appendChild(link);
         link.addEventListener("click",hideResultLink,false);
         


### PR DESCRIPTION
Hello @pistom 

I really like this Addon, useful indeed!
Here a little update to let it fit more in the DuckDuckGo design.

|Before|After|
|--|--|
|<img width="611" alt="schermata 2018-10-27 alle 17 06 32" src="https://user-images.githubusercontent.com/6209647/47605743-bcfc9c80-da0a-11e8-9c7a-54812a5800dc.png">|<img width="746" alt="schermata 2018-10-27 alle 13 17 10" src="https://user-images.githubusercontent.com/6209647/47605745-bd953300-da0a-11e8-9978-c757ec5dd93f.png">|

It uses the same mechanism of ```More results```: little text, and a tooltip for details.
